### PR TITLE
Implemented kotlin.Result<T> instead of Arrow Either

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
+        freeCompilerArgs = ["-Xallow-result-return-type"]
     }
 }
 

--- a/app/src/main/java/co/eventbox/event/network/Either.kt
+++ b/app/src/main/java/co/eventbox/event/network/Either.kt
@@ -5,6 +5,8 @@ package co.eventbox.event.network
  * TEDxTehran | Copyrights 2019-10-29.
  */
 
+
+@Deprecated("Arrow pattern is Deprecated on Kotlin because koltin has provided Resualt<*>")
 sealed class Either<out L, out R> {
 
     data class Left<out L>(val left: L) : Either<L, Nothing>()
@@ -13,5 +15,19 @@ sealed class Either<out L, out R> {
     fun fold(leftFold: (L) -> Unit, rightFold: (R) -> Unit): Unit = when (this) {
         is Left -> leftFold(left)
         is Right -> rightFold(right)
+    }
+
+
+}
+
+
+fun <L, R> Either<L, R>.toResult(): Result<R> {
+    return when (this) {
+        is Either.Right -> {
+            Result.success(right)
+        }
+        is Either.Left -> {
+            Result.failure(left as Throwable)
+        }
     }
 }

--- a/app/src/main/java/co/eventbox/event/network/Either.kt
+++ b/app/src/main/java/co/eventbox/event/network/Either.kt
@@ -6,7 +6,7 @@ package co.eventbox.event.network
  */
 
 
-@Deprecated("Arrow pattern is Deprecated on Kotlin because koltin has provided Resualt<*>")
+@Deprecated("Arrow pattern is Deprecated on Kotlin because kotlin has provided Resualt<*>")
 sealed class Either<out L, out R> {
 
     data class Left<out L>(val left: L) : Either<L, Nothing>()

--- a/app/src/main/java/co/eventbox/event/network/XException.kt
+++ b/app/src/main/java/co/eventbox/event/network/XException.kt
@@ -7,4 +7,7 @@ package co.eventbox.event.network
 class XException(
     var httpCode: Int,
     var errorMessage: String?
-)
+) : Throwable() {
+    override val message: String?
+        get() = errorMessage
+}

--- a/app/src/main/java/co/eventbox/event/respository/AboutRepository.kt
+++ b/app/src/main/java/co/eventbox/event/respository/AboutRepository.kt
@@ -13,8 +13,6 @@ import com.apollographql.apollo.co.eventbox.event.GetAboutsQuery
 class AboutRepository :
     Repository<GetAboutsQuery.Data, Operation.Variables, GetAboutsQuery>() {
 
-    suspend fun request(): Either<XException?, GetAboutsQuery.Data?> {
-        val operation = GetAboutsQuery.builder().build()
-        return fetch(operation)
-    }
+    suspend fun request() = GetAboutsQuery.builder().build().run { return@run fetch(this) }
+
 }

--- a/app/src/main/java/co/eventbox/event/respository/CacheDataRepository.kt
+++ b/app/src/main/java/co/eventbox/event/respository/CacheDataRepository.kt
@@ -13,11 +13,8 @@ import com.apollographql.apollo.co.eventbox.event.DashboardCacheQuery
  */
 class CacheDataRepository :
     Repository<DashboardCacheQuery.Data, Operation.Variables, DashboardCacheQuery>() {
-
-    suspend fun request(): Either<XException?, DashboardCacheQuery.Data?> {
-        val operation = DashboardCacheQuery.builder().build()
-        return fetch(operation, HttpCachePolicy.NETWORK_ONLY)
-    }
-
+    suspend fun request() =
+        DashboardCacheQuery.builder().build().run { fetch(this, HttpCachePolicy.NETWORK_ONLY) }
 
 }
+

--- a/app/src/main/java/co/eventbox/event/respository/GalleryRepository.kt
+++ b/app/src/main/java/co/eventbox/event/respository/GalleryRepository.kt
@@ -12,10 +12,5 @@ import com.apollographql.apollo.co.eventbox.event.DashboardCacheQuery
  */
 class GalleryRepository :
     Repository<DashboardCacheQuery.Data, Operation.Variables, DashboardCacheQuery>() {
-
-    suspend fun request(): Either<XException?, DashboardCacheQuery.Data?> {
-        val operation = DashboardCacheQuery.builder().build()
-
-        return fetch(operation)
-    }
+    suspend fun request() = DashboardCacheQuery.builder().build().run { fetch(this) }
 }

--- a/app/src/main/java/co/eventbox/event/respository/HomeRepository.kt
+++ b/app/src/main/java/co/eventbox/event/respository/HomeRepository.kt
@@ -12,12 +12,5 @@ import com.apollographql.apollo.co.eventbox.event.DashboardCacheQuery
 class HomeRepository :
     Repository<DashboardCacheQuery.Data, Operation.Variables, DashboardCacheQuery>() {
 
-
-    suspend fun fetch(): Either<XException?, DashboardCacheQuery.Data?> {
-
-        val operation = DashboardCacheQuery.builder().build()
-
-        return fetch(operation)
-
-    }
+    suspend fun fetch() = DashboardCacheQuery.builder().build().run { fetch(this) }
 }

--- a/app/src/main/java/co/eventbox/event/respository/PhotosGalleryRepository.kt
+++ b/app/src/main/java/co/eventbox/event/respository/PhotosGalleryRepository.kt
@@ -10,10 +10,8 @@ import com.apollographql.apollo.co.eventbox.event.GetAlbumPhotosQuery
  */
 class PhotosGalleryRepository :
     Repository<GetAlbumPhotosQuery.Data, GetAlbumPhotosQuery.Variables, GetAlbumPhotosQuery>() {
-
-    suspend fun request(id:Int): Either<XException?, GetAlbumPhotosQuery.Data?> {
-        val operation = GetAlbumPhotosQuery.builder().id(id).build()
-
-        return fetch(operation)
+    suspend fun request(id: Int) = GetAlbumPhotosQuery.builder().id(id).build().run {
+        fetch(this)
     }
+
 }

--- a/app/src/main/java/co/eventbox/event/respository/Repository.kt
+++ b/app/src/main/java/co/eventbox/event/respository/Repository.kt
@@ -88,6 +88,15 @@ abstract class Repository<D : Operation.Data, V : Operation.Variables, O : Opera
 
 
 interface FetchingAsResult<O, D> {
+
+    /**
+     * fetching from server by Apollo and return a Result<T>
+     *
+     * @param operation  Operation of Apollo
+     * @param httpCachePolicy a flag of Http Policy
+     * @param delaySecond a time for delaying request.
+     * @return Result<D?>
+     */
     suspend fun fetch(
         operation: O,
         httpCachePolicy: HttpCachePolicy.Policy = HttpCachePolicy.CACHE_FIRST,

--- a/app/src/main/java/co/eventbox/event/respository/Repository.kt
+++ b/app/src/main/java/co/eventbox/event/respository/Repository.kt
@@ -17,7 +17,8 @@ import kotlin.coroutines.CoroutineContext
  * TEDxTehran | Copyrights 4/17/20.
  */
 abstract class Repository<D : Operation.Data, V : Operation.Variables, O : Operation<D, D, V>> :
-    CoroutineScope {
+    CoroutineScope,
+    FetchingAsResult<O, D> {
 
 
     //fetch user token or app token identifier
@@ -30,10 +31,10 @@ abstract class Repository<D : Operation.Data, V : Operation.Variables, O : Opera
     }
 
 
-    suspend fun fetch(
+    override suspend fun fetch(
         operation: O,
-        httpCachePolicy: HttpCachePolicy.Policy = HttpCachePolicy.CACHE_FIRST,
-        delaySecond: Int = 0
+        httpCachePolicy: HttpCachePolicy.Policy,
+        delaySecond: Int
     ): Result<D?> {
         delay(delaySecond.toLong())
         return fetch(operation, httpCachePolicy).toResult()
@@ -82,5 +83,16 @@ abstract class Repository<D : Operation.Data, V : Operation.Variables, O : Opera
 
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.IO
+
+}
+
+
+interface FetchingAsResult<O, D> {
+    suspend fun fetch(
+        operation: O,
+        httpCachePolicy: HttpCachePolicy.Policy = HttpCachePolicy.CACHE_FIRST,
+        delaySecond: Int = 0
+    ): Result<D?>
+
 
 }

--- a/app/src/main/java/co/eventbox/event/respository/Repository.kt
+++ b/app/src/main/java/co/eventbox/event/respository/Repository.kt
@@ -1,9 +1,6 @@
 package co.eventbox.event.respository
 
-import co.eventbox.event.network.ApolloClientProvider
-import co.eventbox.event.network.Either
-import co.eventbox.event.network.OkHttpClientProvider
-import co.eventbox.event.network.XException
+import co.eventbox.event.network.*
 import com.apollographql.apollo.api.Mutation
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Query
@@ -11,6 +8,7 @@ import com.apollographql.apollo.api.cache.http.HttpCachePolicy
 import com.apollographql.apollo.coroutines.toDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import java.lang.Exception
 import kotlin.coroutines.CoroutineContext
 
@@ -27,13 +25,25 @@ abstract class Repository<D : Operation.Data, V : Operation.Variables, O : Opera
     private val okHttpProvider = OkHttpClientProvider.provide(token)
     private val apolloClientProvider = ApolloClientProvider.provide(okHttpProvider)
 
-    fun clearCache(){
+    fun clearCache() {
         this.apolloClientProvider.clearNormalizedCache()
     }
 
+
     suspend fun fetch(
         operation: O,
-        httpCachePolicy: HttpCachePolicy.Policy = HttpCachePolicy.CACHE_FIRST
+        httpCachePolicy: HttpCachePolicy.Policy = HttpCachePolicy.CACHE_FIRST,
+        delaySecond: Int = 0
+    ): Result<D?> {
+        delay(delaySecond.toLong())
+        return fetch(operation, httpCachePolicy).toResult()
+    }
+
+
+    @Deprecated("Use fetch():Result<D?> instead of this.")
+    private suspend fun fetch(
+        operation: O,
+        httpCachePolicy: HttpCachePolicy.Policy = HttpCachePolicy.CACHE_FIRST,
     ): Either<XException?, D?> {
 
         val either: Either<XException?, D?>

--- a/app/src/main/java/co/eventbox/event/respository/Repository.kt
+++ b/app/src/main/java/co/eventbox/event/respository/Repository.kt
@@ -18,7 +18,7 @@ import kotlin.coroutines.CoroutineContext
  */
 abstract class Repository<D : Operation.Data, V : Operation.Variables, O : Operation<D, D, V>> :
     CoroutineScope,
-    FetchingAsResult<O, D> {
+    ResultFetcher<O, D> {
 
 
     //fetch user token or app token identifier
@@ -87,7 +87,7 @@ abstract class Repository<D : Operation.Data, V : Operation.Variables, O : Opera
 }
 
 
-interface FetchingAsResult<O, D> {
+interface ResultFetcher<O, D> {
 
     /**
      * fetching from server by Apollo and return a Result<T>

--- a/app/src/main/java/co/eventbox/event/respository/SpeakersDetailsRepository.kt
+++ b/app/src/main/java/co/eventbox/event/respository/SpeakersDetailsRepository.kt
@@ -14,9 +14,6 @@ class SpeakersDetailsRepository :
     Repository<GetTalkDetailQuery.Data, GetTalkDetailQuery.Variables, GetTalkDetailQuery>() {
 
 
-    suspend fun request(id: Int): Either<XException?, GetTalkDetailQuery.Data?> {
-        val operation = GetTalkDetailQuery.builder().id(id).build()
+    suspend fun request(id: Int) = GetTalkDetailQuery.builder().id(id).build().run { fetch(this) }
 
-        return fetch(operation)
-    }
 }

--- a/app/src/main/java/co/eventbox/event/respository/SpeakersRepository.kt
+++ b/app/src/main/java/co/eventbox/event/respository/SpeakersRepository.kt
@@ -13,11 +13,6 @@ class SpeakersRepository :
     Repository<DashboardCacheQuery.Data, Operation.Variables, DashboardCacheQuery>() {
 
 
-    suspend fun fetch(): Either<XException?, DashboardCacheQuery.Data?> {
+    suspend fun fetch() = DashboardCacheQuery.builder().build().run { fetch(this) }
 
-        val operation = DashboardCacheQuery.builder().build()
-
-        return fetch(operation)
-
-    }
 }

--- a/app/src/main/java/co/eventbox/event/respository/SponsorsRepository.kt
+++ b/app/src/main/java/co/eventbox/event/respository/SponsorsRepository.kt
@@ -12,7 +12,6 @@ import com.apollographql.apollo.co.eventbox.event.GetEventSponsorsQuery
 class SponsorsRepository :
     Repository<GetEventSponsorsQuery.Data, GetEventSponsorsQuery.Variables, GetEventSponsorsQuery>() {
 
-    suspend fun request(eventID:Int): Either<XException?, GetEventSponsorsQuery.Data?> {
-        return fetch(GetEventSponsorsQuery.builder().eventID(eventID).build())
-    }
+    suspend fun request(eventID: Int) =
+        GetEventSponsorsQuery.builder().eventID(eventID).build().run { fetch(this) }
 }

--- a/app/src/main/java/co/eventbox/event/respository/TimeScheduleRepository.kt
+++ b/app/src/main/java/co/eventbox/event/respository/TimeScheduleRepository.kt
@@ -14,9 +14,5 @@ class TimeScheduleRepository :
     Repository<DashboardCacheQuery.Data, Operation.Variables, DashboardCacheQuery>() {
 
 
-    suspend fun request(): Either<XException?, DashboardCacheQuery.Data?> {
-        val operation = DashboardCacheQuery.builder().build()
-
-        return fetch(operation)
-    }
+    suspend fun request() = DashboardCacheQuery.builder().build().run { fetch(this) }
 }

--- a/app/src/main/java/co/eventbox/event/view/home/timeSchedule/TimeScheduleFragment.kt
+++ b/app/src/main/java/co/eventbox/event/view/home/timeSchedule/TimeScheduleFragment.kt
@@ -37,7 +37,7 @@ class TimeScheduleFragment : Fragment() {
         val viewModel = ViewModelProvider(this).get(TimeShelduleViewModel::class.java)
         viewModel.days().observe(viewLifecycleOwner, Observer {
             this.progressBar.gone()
-            if (!it.isEmpty()) {
+            if (!it.isNullOrEmpty()) {
                 adapter.loadedState(it)
             } else {
                 not_found.visibility = View.VISIBLE

--- a/app/src/main/java/co/eventbox/event/view/speakers/SpeakersDetailsFragment.kt
+++ b/app/src/main/java/co/eventbox/event/view/speakers/SpeakersDetailsFragment.kt
@@ -50,8 +50,6 @@ class SpeakersDetailsFragment : Fragment(), ListOnClickListener {
 
 
             either.fold({
-
-            }, {
                 val talk = it?.talk()
                 val speakers = arrayListOf<String>()
                 talk?.speakers()?.forEach { name ->
@@ -70,6 +68,8 @@ class SpeakersDetailsFragment : Fragment(), ListOnClickListener {
                         context?.openBrowser(talk?.videoLink())
                     }
                 }
+            }, {
+
             })
         })
 

--- a/app/src/main/java/co/eventbox/event/view/speakers/SpeakersFragment.kt
+++ b/app/src/main/java/co/eventbox/event/view/speakers/SpeakersFragment.kt
@@ -45,9 +45,8 @@ class SpeakersFragment : Fragment(), ListOnClickListener {
         viewModel.speackers().observe(viewLifecycleOwner, Observer { either ->
 
             progressBar.gone()
-            either.fold({
-                Log.d("TAG", "Exception : ${it?.errorMessage}")
-            }, { data ->
+            either.fold({ data ->
+
                 if (data?.talksWithEvent() != null) {
                     adapter.items = data.talksWithEvent()!!
                     adapter.notifyDataSetChanged()
@@ -60,6 +59,9 @@ class SpeakersFragment : Fragment(), ListOnClickListener {
                     onSelected(0, data?.featuredTalk()?.id()!!.toInt())
                 }
 
+
+            }, {
+                Log.d("TAG", "Exception : ${it.message}")
             })
         })
 

--- a/app/src/main/java/co/eventbox/event/viewModel/AboutViewModel.kt
+++ b/app/src/main/java/co/eventbox/event/viewModel/AboutViewModel.kt
@@ -21,9 +21,9 @@ class AboutViewModel : BaseViewModel() {
 
         launch {
             repository.request().fold({
-                values.postValue(null)
-            }, {
                 values.postValue(it?.organizer()?.abouts())
+            }, {
+                values.postValue(null)
             })
 
 

--- a/app/src/main/java/co/eventbox/event/viewModel/GalleryViewModel.kt
+++ b/app/src/main/java/co/eventbox/event/viewModel/GalleryViewModel.kt
@@ -24,9 +24,9 @@ class GalleryViewModel : BaseViewModel() {
 
         launch {
             galleryRepository.request().fold({
-                albums.postValue(null)
-            }, {
                 albums.postValue(it?.albums())
+            }, {
+                albums.postValue(null)
             })
 
 
@@ -42,9 +42,9 @@ class GalleryViewModel : BaseViewModel() {
 
         launch {
             photosGalleryRepository.request(id).fold({
-                albums.postValue(null)
-            }, {
                 albums.postValue(it?.album()?.photo())
+            }, {
+                albums.postValue(null)
             })
 
 

--- a/app/src/main/java/co/eventbox/event/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/co/eventbox/event/viewModel/HomeViewModel.kt
@@ -21,9 +21,9 @@ class HomeViewModel : BaseViewModel() {
 
         launch {
             repository.fetch().fold({
-                data.postValue(null)
-            }, {
                 data.postValue(it?.organizer()?.mainEvent())
+            }, {
+                data.postValue(null)
             })
 
         }

--- a/app/src/main/java/co/eventbox/event/viewModel/NewsViewModel.kt
+++ b/app/src/main/java/co/eventbox/event/viewModel/NewsViewModel.kt
@@ -21,9 +21,9 @@ class NewsViewModel : BaseViewModel() {
 
         launch {
             galleryRepository.request().fold({
-                albums.postValue(null)
-            }, {
                 albums.postValue(it?.news())
+            }, {
+                albums.postValue(null)
             })
 
 

--- a/app/src/main/java/co/eventbox/event/viewModel/SpeakersViewModel.kt
+++ b/app/src/main/java/co/eventbox/event/viewModel/SpeakersViewModel.kt
@@ -2,8 +2,6 @@ package co.eventbox.event.viewModel
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import co.eventbox.event.network.Either
-import co.eventbox.event.network.XException
 import co.eventbox.event.respository.SpeakersDetailsRepository
 import co.eventbox.event.respository.SpeakersRepository
 import com.apollographql.apollo.co.eventbox.event.DashboardCacheQuery
@@ -19,8 +17,8 @@ class SpeakersViewModel : BaseViewModel() {
     private val speakersRepository = SpeakersRepository()
     private var speakersDetailsRepository = SpeakersDetailsRepository()
 
-    fun speackers(): LiveData<Either<XException?, DashboardCacheQuery.Data?>> {
-        val liveData = MutableLiveData<Either<XException?, DashboardCacheQuery.Data?>>()
+    fun speackers(): LiveData<Result<DashboardCacheQuery.Data?>> {
+        val liveData = MutableLiveData<Result<DashboardCacheQuery.Data?>>()
 
         launch {
             val either = speakersRepository.fetch()
@@ -30,8 +28,8 @@ class SpeakersViewModel : BaseViewModel() {
 
     }
 
-    fun talkDetails(id:Int) : LiveData<Either<XException?,GetTalkDetailQuery.Data?>>{
-        val liveData = MutableLiveData<Either<XException?,GetTalkDetailQuery.Data?>>()
+    fun talkDetails(id: Int): LiveData<Result<GetTalkDetailQuery.Data?>> {
+        val liveData = MutableLiveData<Result<GetTalkDetailQuery.Data?>>()
 
         launch {
             val either = speakersDetailsRepository.request(id)

--- a/app/src/main/java/co/eventbox/event/viewModel/SplashViewModel.kt
+++ b/app/src/main/java/co/eventbox/event/viewModel/SplashViewModel.kt
@@ -20,9 +20,9 @@ class SplashViewModel : BaseViewModel() {
             val either = cacheRepository.request()
 
             either.fold({
-                mutableLiveDataTest.postValue(false)
-            },{
                 mutableLiveDataTest.postValue(it != null)
+            },{
+                mutableLiveDataTest.postValue(false)
             })
         }
 

--- a/app/src/main/java/co/eventbox/event/viewModel/SponsorsViewModel.kt
+++ b/app/src/main/java/co/eventbox/event/viewModel/SponsorsViewModel.kt
@@ -20,9 +20,9 @@ class SponsorsViewModel : BaseViewModel() {
 
         launch {
             repository.request(eventID).fold({
-                values.postValue(null)
-            }, {
                 values.postValue(it?.sponsorsWithType())
+            }, {
+                values.postValue(null)
             })
         }
 

--- a/app/src/main/java/co/eventbox/event/viewModel/TimeShelduleViewModel.kt
+++ b/app/src/main/java/co/eventbox/event/viewModel/TimeShelduleViewModel.kt
@@ -20,9 +20,9 @@ class TimeShelduleViewModel : BaseViewModel() {
 
         launch {
             repository.request().fold({
-                values.postValue(null)
-            }, {
                 values.postValue(it?.organizer()?.mainEvent()?.days())
+            }, {
+                values.postValue(null)
             })
 
 


### PR DESCRIPTION
- Change Repository returning of result as Result<T>
- Implemented a new method for Result<T>
- Deprecated Either
- Declared a method for shifting Either to Result
- Change all Repository Result
- Change all ViewModel Result
- Fix a bug in SplashViewModel when app Starting.

For information about Result<T> : https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/